### PR TITLE
Add getExternalFilesDir when checking if a path requires a permission

### DIFF
--- a/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
+++ b/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
@@ -149,7 +149,8 @@ public class OpenFilePlugin implements MethodCallHandler
         try {
             String appDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
             String fileCanonicalPath = new File(filePath).getCanonicalPath();
-            return !fileCanonicalPath.startsWith(appDirCanonicalPath);
+            String extCanonicalPath = context.getExternalFilesDir(null).getCanonicalPath();
+            return !(fileCanonicalPath.startsWith(appDirCanonicalPath) || fileCanonicalPath.startsWith(extCanonicalPath));
         } catch (IOException e) {
             e.printStackTrace();
             return true;


### PR DESCRIPTION
According to https://developer.android.com/reference/android/content/Context#getExternalFilesDir(java.lang.String) no additional permission is required to read or write to the path returned by getExternalFilesDir(null)